### PR TITLE
Allow skipping of SSL verify

### DIFF
--- a/Wappalyzer.py
+++ b/Wappalyzer.py
@@ -54,7 +54,7 @@ class WebPage(object):
         self.meta = { meta['name'].lower(): meta['content'] for meta in soup.findAll('meta', attrs=dict(name=True, content=True)) }
 
     @classmethod
-    def new_from_url(cls, url):
+    def new_from_url(cls, url, verify=True):
         """
         Constructs a new WebPage object for the URL,
         using the `requests` module to fetch the HTML.
@@ -63,8 +63,9 @@ class WebPage(object):
         ----------
 
         url : str
+        verify: bool
         """
-        response = requests.get(url)
+        response = requests.get(url, verify=verify)
         return cls.new_from_response(response)
 
     @classmethod


### PR DESCRIPTION
Thanks for making this!!

In order to use python-Wappalyzer against sites that might have invalid or self-signed SSL certs, `requests` needs the `verify=False` kwarg. This adds that functionality in an optional, backwards-compatible way.

Usage:

```
from Wappalyzer import Wappalyzer, WebPage

wappalyzer = Wappalyzer.latest()
webpage = WebPage.new_from_url('https://<my_site_with_self_signed_cert>', verify=False)
wappalyzer.analyze(webpage)
```
