### PR TITLE
Replace beautiful soup 4 with Python standard library

### DIFF
--- a/Wappalyzer/Wappalyzer.py
+++ b/Wappalyzer/Wappalyzer.py
@@ -8,11 +8,29 @@ import os
 import pathlib
 import requests
 from datetime import datetime, timedelta
-
-from bs4 import BeautifulSoup # type: ignore
+from abc import ABC
+from html.parser import HTMLParser
+from urllib.parse import urlparse, urljoin
 from typing import Union, Optional
 
 logger = logging.getLogger(name="python-Wappalyzer")
+
+
+class ScriptMetaParser(HTMLParser, ABC):
+
+    def __init__(self):
+        HTMLParser.__init__(self)
+        self.script_src = []
+        self.meta_info = []
+
+    def handle_starttag(self, tag, attrs):
+        attributes = dict(attrs)
+        if tag == 'script':
+            if attributes.get('src'):
+                self.script_src.append(attributes.get('src'))
+        if tag == 'meta':
+            if attributes.get('name'):
+                self.meta_info.append({attributes.get('name').lower(): attributes.get('content')})
 
 
 class WappalyzerError(Exception):
@@ -39,7 +57,7 @@ class WebPage:
 
     """
 
-    def __init__(self, url:str, html:str, headers:Mapping[str, Any]):
+    def __init__(self, url: str, html: str, headers: Mapping[str, Any]):
         """
         Initialize a new WebPage object manually.  
 
@@ -53,7 +71,7 @@ class WebPage:
         self.url = url
         self.html = html
         self.headers = headers
-        self.scripts :List[str] = []
+        self.scripts: List[str] = []
 
         try:
             list(self.headers.keys())
@@ -64,19 +82,15 @@ class WebPage:
 
     def _parse_html(self):
         """
-        Parse the HTML with BeautifulSoup to find <script> and <meta> tags.
+        Parse the HTML with HTMLParser to find <script> and <meta> tags.
         """
-        self.parsed_html = soup = BeautifulSoup(self.html, 'lxml')
-        self.scripts.extend(script['src'] for script in
-                        soup.findAll('script', src=True))
-        self.meta = {
-            meta['name'].lower():
-                meta['content'] for meta in soup.findAll(
-                    'meta', attrs=dict(name=True, content=True))
-        }
+        self.parsed_html = script_meta_parser = ScriptMetaParser()
+        script_meta_parser.feed(self.html)
+        self.scripts.extend(script_meta_parser.script_src)
+        self.meta = script_meta_parser.meta_info
 
     @classmethod
-    def new_from_url(cls, url: str, **kwargs:Any) -> 'WebPage':
+    def new_from_url(cls, url: str, **kwargs: Any) -> 'WebPage':
         """
         Constructs a new WebPage object for the URL,
         using the `requests` module to fetch the HTML.
@@ -96,7 +110,7 @@ class WebPage:
         return cls.new_from_response(response)
 
     @classmethod
-    def new_from_response(cls, response:requests.Response) -> 'WebPage':
+    def new_from_response(cls, response: requests.Response) -> 'WebPage':
         """
         Constructs a new WebPage object for the response,
         using the `BeautifulSoup` module to parse the HTML.
@@ -105,10 +119,9 @@ class WebPage:
         """
         return cls(response.url, html=response.text, headers=response.headers)
 
-
     @classmethod
     async def new_from_url_async(cls, url: str, verify: bool = True,
-                                 aiohttp_client_session: aiohttp.ClientSession = None, **kwargs:Any) -> 'WebPage':
+                                 aiohttp_client_session: aiohttp.ClientSession = None, **kwargs: Any) -> 'WebPage':
         """
         Same as new_from_url only Async.
 
@@ -139,7 +152,7 @@ class WebPage:
             return await cls.new_from_response_async(response)
 
     @classmethod
-    async def new_from_response_async(cls, response:aiohttp.ClientResponse) -> 'WebPage':
+    async def new_from_response_async(cls, response: aiohttp.ClientResponse) -> 'WebPage':
         """
         Constructs a new WebPage object for the response,
         using the `BeautifulSoup` module to parse the HTML.
@@ -187,7 +200,7 @@ class Wappalyzer:
 
     """
 
-    def __init__(self, categories:Dict[str, Any], technologies:Dict[str, Any]):
+    def __init__(self, categories: Dict[str, Any], technologies: Dict[str, Any]):
         """
         Manually initialize a new Wappalyzer instance. 
         
@@ -205,7 +218,7 @@ class Wappalyzer:
             self._prepare_technology(technology)
 
     @classmethod
-    def latest(cls, technologies_file:str=None, update:bool=False) -> 'Wappalyzer':
+    def latest(cls, technologies_file: str = None, update: bool = False) -> 'Wappalyzer':
         """
         Construct a Wappalyzer instance.
         
@@ -224,7 +237,7 @@ class Wappalyzer:
             from `AliasIO/wappalyzer <https://github.com/AliasIO/wappalyzer>`_ repository.  
         
         """
-        default=pkg_resources.resource_string(__name__, "data/technologies.json")
+        default = pkg_resources.resource_string(__name__, "data/technologies.json")
 
         if technologies_file:
             with open(technologies_file, 'r') as fd:
@@ -232,7 +245,7 @@ class Wappalyzer:
         elif update:
             should_update = True
             technologies_file: Optional[pathlib.Path] = None
-            _files = cls._find_files(['HOME', 'APPDATA',], ['.python-Wappalyzer/technologies.json'])
+            _files = cls._find_files(['HOME', 'APPDATA', ], ['.python-Wappalyzer/technologies.json'])
             if _files:
                 technologies_file = pathlib.Path(_files.pop())
                 last_modification_time = datetime.fromtimestamp(technologies_file.stat().st_mtime)
@@ -242,22 +255,26 @@ class Wappalyzer:
             # Get the lastest file
             if should_update:
                 try:
-                    lastest_technologies_file=requests.get('https://raw.githubusercontent.com/AliasIO/wappalyzer/master/src/technologies.json')
+                    lastest_technologies_file = requests.get(
+                        'https://raw.githubusercontent.com/AliasIO/wappalyzer/master/src/technologies.json')
                     obj = lastest_technologies_file.json()
                     technologies_file = pathlib.Path(cls._find_files(
-                        ['HOME', 'APPDATA',],
+                        ['HOME', 'APPDATA', ],
                         ['.python-Wappalyzer/technologies.json'],
-                        create = True
-                        ).pop())
+                        create=True
+                    ).pop())
                     with technologies_file.open('w') as tfile:
                         tfile.write(lastest_technologies_file.text)
                     logger.info("python-Wappalyzer technologies.json file updated")
 
-                except Exception as err: # Or loads default
-                    logger.error("Could not download latest Wappalyzer technologies.json file because of error : '{}'. Using default. ".format(err))
+                except Exception as err:  # Or loads default
+                    logger.error(
+                        "Could not download latest Wappalyzer technologies.json file because of error : '{}'. Using default. ".format(
+                            err))
                     obj = json.loads(default)
             else:
-                logger.info("python-Wappalyzer technologies.json file not updated because already update in the last 24h")
+                logger.info(
+                    "python-Wappalyzer technologies.json file not updated because already update in the last 24h")
                 with technologies_file.open('r') as tfile:
                     obj = json.load(tfile)
 
@@ -265,15 +282,14 @@ class Wappalyzer:
         else:
             obj = json.loads(default)
 
-        
         return cls(categories=obj['categories'], technologies=obj['technologies'])
 
     @staticmethod
     def _find_files(
-        env_location: List[str],
-        potential_files: List[str],
-        default_content: str = "",
-        create: bool = False,
+            env_location: List[str],
+            potential_files: List[str],
+            default_content: str = "",
+            create: bool = False,
     ) -> List[str]:
         """Find existent files based on folders name and file names.
         Arguments:
@@ -346,7 +362,7 @@ class Wappalyzer:
             for name, pattern in list(obj.items()):
                 obj[name] = self._prepare_pattern(obj[name])
 
-    def _prepare_pattern(self, pattern:str) -> Dict[str, Any]:
+    def _prepare_pattern(self, pattern: str) -> Dict[str, Any]:
         """
         Strip out key:value pairs from the pattern and compile the regular
         expression.
@@ -357,7 +373,7 @@ class Wappalyzer:
             if index == 0:
                 attrs['string'] = expression
                 try:
-                    attrs['regex'] = re.compile(expression, re.I) # type: ignore
+                    attrs['regex'] = re.compile(expression, re.I)  # type: ignore
                 except re.error as err:
                     # Wappalyzer is a JavaScript application therefore some of the regex wont compile in Python.
                     logger.debug(
@@ -366,7 +382,7 @@ class Wappalyzer:
                     )
                     # regex that never matches:
                     # http://stackoverflow.com/a/1845097/413622
-                    attrs['regex'] = re.compile(r'(?!x)x') # type: ignore
+                    attrs['regex'] = re.compile(r'(?!x)x')  # type: ignore
             else:
                 attr = expression.split(':')
                 if len(attr) > 1:
@@ -422,7 +438,8 @@ class Wappalyzer:
 
         return has_app
 
-    def _set_detected_app(self, app: Dict[str, Any], app_type:str, pattern: Dict[str, Any], value:str, key='') -> None:
+    def _set_detected_app(self, app: Dict[str, Any], app_type: str, pattern: Dict[str, Any], value: str,
+                          key='') -> None:
         """
         Store detected app.
         """
@@ -452,9 +469,10 @@ class Wappalyzer:
                 for index, match in enumerate(matches):
                     # Parse ternary operator
                     ternary = re.search(re.compile('\\\\' + str(index + 1) + '\\?([^:]+):(.*)$', re.I), version)
-                    if ternary and len(ternary.groups()) == 2 and ternary.group(1) is not None and ternary.group(2) is not None:
+                    if ternary and len(ternary.groups()) == 2 and ternary.group(1) is not None and ternary.group(
+                            2) is not None:
                         version = version.replace(ternary.group(0), ternary.group(1) if match != ''
-                                                  else ternary.group(2))
+                        else ternary.group(2))
 
                     # Replace back references
                     version = version.replace('\\' + str(index + 1), match)
@@ -476,11 +494,12 @@ class Wappalyzer:
 
         app['versions'] = sorted(app['versions'], key=self._cmp_to_key(self._sort_app_versions))
 
-    def _get_implied_technologies(self, detected_technologies:Iterable[str]) -> Iterable[str]:
+    def _get_implied_technologies(self, detected_technologies: Iterable[str]) -> Iterable[str]:
         """
         Get the set of technologies implied by `detected_technologies`.
         """
-        def __get_implied_technologies(technologies:Iterable[str]) -> Iterable[str] :
+
+        def __get_implied_technologies(technologies: Iterable[str]) -> Iterable[str]:
             _implied_technologies = set()
             for tech in technologies:
                 try:
@@ -494,7 +513,7 @@ class Wappalyzer:
                             try:
                                 # Use more strict regexp (cause we have already checked the entry of "confidence")
                                 # Also, better way to compile regexp one time, instead of every time
-                                app_name, confidence = self._confidence_regexp.search(implie).groups() # type: ignore
+                                app_name, confidence = self._confidence_regexp.search(implie).groups()  # type: ignore
                                 if int(confidence) >= 50:
                                     _implied_technologies.add(app_name)
                             except (ValueError, AttributeError):
@@ -504,7 +523,7 @@ class Wappalyzer:
             return _implied_technologies
 
         implied_technologies = __get_implied_technologies(detected_technologies)
-        all_implied_technologies : Set[str] = set()
+        all_implied_technologies: Set[str] = set()
 
         # Descend recursively until we've found all implied technologies
         while not all_implied_technologies.issuperset(implied_technologies):
@@ -513,7 +532,7 @@ class Wappalyzer:
 
         return all_implied_technologies
 
-    def get_categories(self, tech_name:str) -> List[str]:
+    def get_categories(self, tech_name: str) -> List[str]:
         """
         Returns a list of the categories for an technology name.
 
@@ -525,7 +544,7 @@ class Wappalyzer:
 
         return cat_names
 
-    def get_versions(self, app_name:str) -> List[str]:
+    def get_versions(self, app_name: str) -> List[str]:
         """
         Retuns a list of the discovered versions for an app name.
 
@@ -533,15 +552,16 @@ class Wappalyzer:
         """
         return [] if 'versions' not in self.technologies[app_name] else self.technologies[app_name]['versions']
 
-    def get_confidence(self, app_name:str) -> Optional[int]:
+    def get_confidence(self, app_name: str) -> Optional[int]:
         """
         Returns the total confidence for an app name.
 
         :param app_name: App name
         """
-        return None if 'confidenceTotal' not in self.technologies[app_name] else self.technologies[app_name]['confidenceTotal']
+        return None if 'confidenceTotal' not in self.technologies[app_name] else self.technologies[app_name][
+            'confidenceTotal']
 
-    def analyze(self, webpage:WebPage) -> Set[str]:
+    def analyze(self, webpage: WebPage) -> Set[str]:
         """
         Return a set of technology that can be detected on the web page.
 
@@ -557,7 +577,7 @@ class Wappalyzer:
 
         return detected_technologies
 
-    def analyze_with_versions(self, webpage:WebPage) -> Dict[str, Dict[str, Any]]:
+    def analyze_with_versions(self, webpage: WebPage) -> Dict[str, Dict[str, Any]]:
         """
         Return a dict of applications and versions that can be detected on the web page.
 
@@ -572,7 +592,7 @@ class Wappalyzer:
 
         return versioned_apps
 
-    def analyze_with_categories(self, webpage:WebPage) -> Dict[str, Dict[str, Any]]:
+    def analyze_with_categories(self, webpage: WebPage) -> Dict[str, Dict[str, Any]]:
         """
         Return a dict of technologies and categories that can be detected on the web page.
 
@@ -594,7 +614,7 @@ class Wappalyzer:
 
         return categorised_technologies
 
-    def analyze_with_versions_and_categories(self, webpage:WebPage) -> Dict[str, Dict[str, Any]]:
+    def analyze_with_versions_and_categories(self, webpage: WebPage) -> Dict[str, Dict[str, Any]]:
         """
         Return a dict of applications and versions and categories that can be detected on the web page.
 
@@ -652,11 +672,12 @@ class Wappalyzer:
 
         return CmpToKey
 
-def analyze(url:str, 
-            update:bool=False, 
-            useragent:str=None,
-            timeout:int=10,
-            verify:bool=True) -> Dict[str, Dict[str, Any]]:
+
+def analyze(url: str,
+            update: bool = False,
+            useragent: str = None,
+            timeout: int = 10,
+            verify: bool = True) -> Dict[str, Dict[str, Any]]:
     """
     Quick utility method to analyze a website with minimal configurable options. 
 
@@ -674,15 +695,15 @@ def analyze(url:str,
     :Note: More information might be added to the returned values in the future
     """
     # Create Wappalyzer
-    wappalyzer=Wappalyzer.latest(update=update)
+    wappalyzer = Wappalyzer.latest(update=update)
     # Create WebPage
-    headers={}
+    headers = {}
     if useragent:
         headers['User-Agent'] = useragent
-    webpage=WebPage.new_from_url(url, 
-        headers=headers, 
-        timeout=timeout, 
-        verify=verify)
+    webpage = WebPage.new_from_url(url,
+                                   headers=headers,
+                                   timeout=timeout,
+                                   verify=verify)
     # Analyze
     results = wappalyzer.analyze_with_versions_and_categories(webpage)
     return results


### PR DESCRIPTION
I need to install lxml support when I install beautiful soup 4. I think a simpler method should be used to parse HTML, so I submitted a branch without beautifulsoup4