### PR TITLE
created test for valid selector that does not increase time

### DIFF
--- a/Wappalyzer/Wappalyzer.py
+++ b/Wappalyzer/Wappalyzer.py
@@ -7,6 +7,7 @@ import re
 import os
 import pathlib
 import requests
+import soupsieve as sv
 
 from datetime import datetime, timedelta
 from typing import Optional

--- a/Wappalyzer/Wappalyzer.py
+++ b/Wappalyzer/Wappalyzer.py
@@ -16,6 +16,14 @@ from Wappalyzer.webpage import WebPage, IWebPage
 
 logger = logging.getLogger(name="python-Wappalyzer")
 
+def is_valid_selector(sel):
+	try:
+		sv.compile(sel)
+	except (sv.SelectorSyntaxError, NotImplementedError):
+		print(sel)
+		return False
+	return True
+
 class WappalyzerError(Exception):
     # unused for now
     """
@@ -219,23 +227,24 @@ class Wappalyzer:
         #           - "text": "regex": check if the .innerText property of the element that matches the css selector matches the regex (with version extraction).
         #           - "attributes": {dict from attr name to regex}: check if the attribute value of the element that matches the css selector matches the regex (with version extraction).
         for selector in tech_fingerprint.dom:
-            for item in webpage.select(selector.selector):
-                if selector.exists:
-                    self._set_detected_app(webpage.url, tech_fingerprint, 'dom', Pattern(string=selector.selector), value='')
-                    has_tech = True
-                if selector.text:
-                    for pattern in selector.text:
-                        if pattern.regex.search(item.inner_html):
-                            self._set_detected_app(webpage.url, tech_fingerprint, 'dom', pattern, value=item.inner_html)
-                            has_tech = True
-                if selector.attributes:
-                    for attrname, patterns in list(selector.attributes.items()):
-                        _content = item.attributes.get(attrname)
-                        if _content:
-                            for pattern in patterns:
-                                if pattern.regex.search(_content):
-                                    self._set_detected_app(webpage.url, tech_fingerprint, 'dom', pattern, value=_content)
-                                    has_tech = True
+            if is_valid_selector(selector.selector):
+                for item in webpage.select(selector.selector):
+                    if selector.exists:
+                        self._set_detected_app(webpage.url, tech_fingerprint, 'dom', Pattern(string=selector.selector), value='')
+                        has_tech = True
+                    if selector.text:
+                        for pattern in selector.text:
+                            if pattern.regex.search(item.inner_html):
+                                self._set_detected_app(webpage.url, tech_fingerprint, 'dom', pattern, value=item.inner_html)
+                                has_tech = True
+                    if selector.attributes:
+                        for attrname, patterns in list(selector.attributes.items()):
+                            _content = item.attributes.get(attrname)
+                            if _content:
+                                for pattern in patterns:
+                                    if pattern.regex.search(_content):
+                                        self._set_detected_app(webpage.url, tech_fingerprint, 'dom', pattern, value=_content)
+                                        has_tech = True
         return has_tech
 
     def _set_detected_app(self, url:str,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import pathlib
 
 setup(
     name                =   "python-Wappalyzer",
-    version             =   "0.4.0",
+    version             =   "0.4.1",
     description         =   "Python implementation of the Wappalyzer web application "
                             "detection utility",
     long_description    =   (pathlib.Path(__file__).parent / "README.rst").read_text(),

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import pathlib
 
 setup(
     name                =   "python-Wappalyzer",
-    version             =   "0.4.1",
+    version             =   "0.4.2",
     description         =   "Python implementation of the Wappalyzer web application "
                             "detection utility",
     long_description    =   (pathlib.Path(__file__).parent / "README.rst").read_text(),


### PR DESCRIPTION
My room wappybird implement ls your library. I started pulling the updated wappalyzer libraries. They have had issues with valid json, so I started pulling the current release of, but the tally selector is malformed. I talked to the maintainer of soupsieve and they provided a function to tech for valid selectors and skip if not. This replaces the crude try/catch code

I can update your repo to pull the current technologies if you would like. Or feel free to pull from wappybird.

Also, the pip is out of date and incompatible with the updated technologies files