### PR TITLE
Fix invalid regex in Wappalyzer/data/technologies.json: Symfony -> html

### DIFF
--- a/Wappalyzer/data/technologies.json
+++ b/Wappalyzer/data/technologies.json
@@ -14302,7 +14302,7 @@
         "sf_redirect": ""
       },
       "description": "Symfony is a PHP web application framework and a set of reusable PHP components/libraries.",
-      "html": "(?:<div class=\"sf-toolbar[^>]+?>[^]+<span class=\"sf-toolbar-value\">([\\d.])+|<div id=\"sfwdt[^\"]+\" class=\"[^\"]*sf-toolbar)\\;version:\\1",
+      "html": "(?:<div class=\"sf-toolbar[^>]+?>[^<]+<span class=\"sf-toolbar-value\">([\\d.])+|<div id=\"sfwdt[^\"]+\" class=\"[^\"]*sf-toolbar)\\;version:\\1",
       "icon": "Symfony.svg",
       "implies": "PHP",
       "js": {


### PR DESCRIPTION
python3.11/site-packages/Wappalyzer/Wappalyzer.py:226: UserWarning: Caught 'unbalanced parenthesis at position 119' compiling regex:
['(?:<div class="sf-toolbar[^>]+?>[^]+<span class="sf-toolbar-value">([\\d.])+|<div id="sfwdt[^"]+" class="[^"]*sf-toolbar)', 'version:\\1']
----------------------------------^^^ invalid sub-regex
The 'position 119' seems to a delayed reaction to the core issue.

Indeed it looks like the sub-regex: [^]+ just before <span class=...>  is invalid since ^ is a negation/complement for the char-class which is empty here.

The problem is in the data-file:
    Wappalyzer/data/technologies.json
    line 11961
The rule for "Symfony": "html": should be (one char change):
    "html": "(?:<div class=\"sf-toolbar[^>]+?>[^<]+<span class=\"sf-toolbar-value\">([\\d.])+|<div id=\"sfwdt[^\"]+\" class=\"[^\"]*sf-toolbar)\\;version:\\1",
----------------------------------------------^^^^ the fix